### PR TITLE
Commit queue_agent main.py changes

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/SD.iml
+++ b/.idea/SD.iml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="TemplatesService">
+    <option name="TEMPLATE_FOLDERS">
+      <list>
+        <option value="$MODULE_DIR$/src/charts/sd_on_eks/templates" />
+      </list>
+    </option>
+  </component>
+</module>

--- a/.idea/aws.xml
+++ b/.idea/aws.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="accountSettings">
+    <option name="activeRegion" value="us-east-1" />
+    <option name="recentlyUsedRegions">
+      <list>
+        <option value="us-east-1" />
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.9" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/SD.iml" filepath="$PROJECT_DIR$/.idea/SD.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/backend/queue_agent/main.py
+++ b/src/backend/queue_agent/main.py
@@ -96,7 +96,11 @@ def main():
                 try:
                     snsPayload = json.loads(message.body)
                     payload = json.loads(snsPayload['Message'])
-                    taskHeader = payload.pop('alwayson_scripts', None)
+                    taskHeader = copy.deepcopy(payload).get('alwayson_scripts', None)
+                    alwayson_scripts = {k: v for k, v in taskHeader.items() if
+                                        k not in ["task", "sd_model_checkpoint", "id_task", "uid", "save_dir"]}
+                    payload["alwayson_scripts"] = alwayson_scripts
+
                     taskType = taskHeader['task'] if 'task' in taskHeader else None
                     folder = get_prefix(
                         payload['s3_output_path']) if 's3_output_path' in payload else None


### PR DESCRIPTION
*Issue #, if available:*
When loading the model, I encountered a problem with the failed call when trying to load the ControlNet and Face-Editor plugins. The WebUI does not call the plugins, but directly performs inference to generate images.

*Description of changes:*
- The source code directly uses the `pop` method to retrieve the `alwayson_scripts` item from the `payload` dictionary and assigns it to the `taskHeader` variable. This will directly modify the `payload` dictionary by removing the `alwayson_scripts` item from it.
- By using `deepcopy`, it avoids directly modifying the passed dictionary, which is usually a safer practice, especially when we are unsure if the function needs to modify the parameters passed from outside.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
