### PR TITLE
Update bottlerocket-images-cache submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "utils/bottlerocket-images-cache"]
 	path = utils/bottlerocket-images-cache
-	url = https://github.com/yubingjiaocn/bottlerocket-images-cache
+	url = https://github.com/aws-samples/bottlerocket-images-cache


### PR DESCRIPTION
*Issue #, if available:*
Close #23 

*Description of changes:*
Change reference of `bottlerocket-images-cache` submodule to https://github.com/aws-samples/bottlerocket-images-cache

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
