### PR TITLE
Add toleration to container insight collector

### DIFF
--- a/lib/dataPlane.ts
+++ b/lib/dataPlane.ts
@@ -100,7 +100,11 @@ export default class DataPlaneStack {
               "key": "runtime",
               "operator": "Exists",
               "effect": "NoSchedule"
-            }]
+            }],
+            cwreceivers: {
+              preferFullPodName: "true",
+              addFullPodNameMetricLabel: "true"
+            }
           }
         }
       }

--- a/lib/dataPlane.ts
+++ b/lib/dataPlane.ts
@@ -88,6 +88,24 @@ export default class DataPlaneStack {
       createNamespace: true
     }
 
+    const containerInsightsParams: blueprints.ContainerInsightAddonProps = {
+      values: {
+        adotCollector: {
+          daemonSet: {
+            tolerations: [{
+              "key": "nvidia.com/gpu",
+              "operator": "Exists",
+              "effect": "NoSchedule"
+            }, {
+              "key": "runtime",
+              "operator": "Exists",
+              "effect": "NoSchedule"
+            }]
+          }
+        }
+      }
+    }
+
     const SharedComponentAddOnParams: SharedComponentAddOnProps = {
       modelstorageEfs: blueprints.getNamedResource("efs-model-storage"),
       inputSns: blueprints.getNamedResource("inputSNSTopic"),
@@ -115,7 +133,7 @@ export default class DataPlaneStack {
       new blueprints.addons.EfsCsiDriverAddOn(),
       new blueprints.addons.KarpenterAddOn({ interruptionHandling: true }),
       new blueprints.addons.KedaAddOn(kedaParams),
-      new blueprints.addons.ContainerInsightsAddOn(),
+      new blueprints.addons.ContainerInsightsAddOn(containerInsightsParams),
       new blueprints.addons.AwsForFluentBitAddOn(awsForFluentBitParams),
       new nvidiaDevicePluginAddon({}),
       new SharedComponentAddOn(SharedComponentAddOnParams),


### PR DESCRIPTION
*Issue #, if available:*
Close #17 
*Description of changes:*

Add tolerations `nvidia.com/gpu:NoSchedule` and `runtime:NoSchedule` to ADOT collector. This change allows ADOT collectors to run on GPU instances and scrape metrics of SD runtime. 

Also enable `preferFullPodName` to view individual pod performance. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
