### PR TITLE
Disable NVDP to avoid conflict with bottlerocket

### DIFF
--- a/lib/dataPlane.ts
+++ b/lib/dataPlane.ts
@@ -139,7 +139,6 @@ export default class DataPlaneStack {
       new blueprints.addons.KedaAddOn(kedaParams),
       new blueprints.addons.ContainerInsightsAddOn(containerInsightsParams),
       new blueprints.addons.AwsForFluentBitAddOn(awsForFluentBitParams),
-      new nvidiaDevicePluginAddon({}),
       new SharedComponentAddOn(SharedComponentAddOnParams),
       new EbsThroughputTunerAddOn(EbsThroughputModifyAddOnParams),
       new S3SyncEFSAddOn(s3SyncEFSAddOnParams)

--- a/lib/runtime/sdRuntime.ts
+++ b/lib/runtime/sdRuntime.ts
@@ -59,7 +59,6 @@ export default class SDRuntimeAddon extends blueprints.addons.HelmAddOn {
 
   @blueprints.utils.dependable(blueprints.KarpenterAddOn.name)
   @blueprints.utils.dependable("SharedComponentAddOn")
-  @blueprints.utils.dependable("nvidiaDevicePluginAddon")
 
   deploy(clusterInfo: blueprints.ClusterInfo): Promise<Construct> {
     const cluster = clusterInfo.cluster


### PR DESCRIPTION
*Description of changes:*
* Disable side-loaded NVIDIA Device Plugin to avoid conflict with built-in NVDP in Bottlerocket OS. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
